### PR TITLE
Remove --project from post-hook command

### DIFF
--- a/docs/1.8/04-Reference/09-Upgrade-Guides/02-Upgrading-Prisma/02-Upgrade-to-1.7.md
+++ b/docs/1.8/04-Reference/09-Upgrade-Guides/02-Upgrading-Prisma/02-Upgrade-to-1.7.md
@@ -104,7 +104,7 @@ Here is an example that performs three tasks after a deployment:
 hooks:
   post-deploy:
     - echo "Deployment finished"
-    - graphql get-schema --project db
+    - graphql get-schema --project
     - graphql prepare
 ```
 

--- a/docs/1.8/04-Reference/09-Upgrade-Guides/02-Upgrading-Prisma/02-Upgrade-to-1.7.md
+++ b/docs/1.8/04-Reference/09-Upgrade-Guides/02-Upgrading-Prisma/02-Upgrade-to-1.7.md
@@ -104,7 +104,7 @@ Here is an example that performs three tasks after a deployment:
 hooks:
   post-deploy:
     - echo "Deployment finished"
-    - graphql get-schema --project
+    - graphql get-schema
     - graphql prepare
 ```
 


### PR DESCRIPTION
I think this is just confusing. The command still works without specifying the project name, in this case `--project db`. I just pasted that command including `--project db` and got an empty `generated` folder. Now that I have removed `--project db` everything works.