### PR TITLE
Fix API metrics invocation

### DIFF
--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
@@ -56,21 +56,21 @@ case class ManagementServer(prefix: String = "", server2serverSecret: Option[Str
     val requestBeginningTime = System.currentTimeMillis()
 
     def logRequestEnd(projectId: Option[String] = None, clientId: Option[String] = None) = {
-      log(
-        Json
-          .toJson(
-            LogData(
-              key = LogKey.RequestComplete,
-              requestId = requestId,
-              projectId = projectId,
-              clientId = clientId,
-              payload = Some(Map("request_duration" -> (System.currentTimeMillis() - requestBeginningTime)))
-            )
-          )
-          .toString())
+//      log(
+//        Json
+//          .toJson(
+//            LogData(
+//              key = LogKey.RequestComplete,
+//              requestId = requestId,
+//              projectId = projectId,
+//              clientId = clientId,
+//              payload = Some(Map("request_duration" -> (System.currentTimeMillis() - requestBeginningTime)))
+//            )
+//          )
+//          .toString())
     }
 
-    logger.info(Json.toJson(LogData(LogKey.RequestNew, requestId)).toString())
+//    logger.info(Json.toJson(LogData(LogKey.RequestNew, requestId)).toString())
 
     handleExceptions(toplevelExceptionHandler(requestId)) {
       TimeResponseDirectiveImpl(DeployMetrics).timeResponse {


### PR DESCRIPTION
Fixes an issue introduced in an earlier commit that prevents API metrics from being reported, leading to empty cloud dashboards.

Byproduct: Reduce logging verbosity on the management API.