### PR TITLE
Postgres Fixes To Align to MySql behavior

### DIFF
--- a/server/connectors/api-connector-postgresql/src/main/scala/com/prisma/api/connector/postgresql/database/PostgresApiDatabaseMutationBuilder.scala
+++ b/server/connectors/api-connector-postgresql/src/main/scala/com/prisma/api/connector/postgresql/database/PostgresApiDatabaseMutationBuilder.scala
@@ -133,7 +133,7 @@ case class PostgresApiDatabaseMutationBuilder(
         sql"""("id", "#${path.columnForParentSideOfLastEdge(schema)}", "#${path.columnForChildSideOfLastEdge(schema)}")""" ++
         sql"""Select '#$relationId',""" ++ pathQueryForLastChild(path.removeLastEdge) ++ sql""","#${childWhere.model.dbNameOfIdField_!}" """ ++
         sql"""FROM "#$schemaName"."#${childWhere.model.dbName}" where "#${childWhere.field.dbName}" = ${childWhere.fieldValue}
-             ON CONFLICT DO NOTHING
+              ON CONFLICT DO NOTHING
            """).asUpdate
 
     }

--- a/server/connectors/api-connector-postgresql/src/main/scala/com/prisma/api/connector/postgresql/database/PostgresApiDatabaseMutationBuilder.scala
+++ b/server/connectors/api-connector-postgresql/src/main/scala/com/prisma/api/connector/postgresql/database/PostgresApiDatabaseMutationBuilder.scala
@@ -132,7 +132,10 @@ case class PostgresApiDatabaseMutationBuilder(
       (sql"""insert into "#$schemaName"."#${path.lastRelation_!.relationTableNameNew(schema)}" """ ++
         sql"""("id", "#${path.columnForParentSideOfLastEdge(schema)}", "#${path.columnForChildSideOfLastEdge(schema)}")""" ++
         sql"""Select '#$relationId',""" ++ pathQueryForLastChild(path.removeLastEdge) ++ sql""","#${childWhere.model.dbNameOfIdField_!}" """ ++
-        sql"""FROM "#$schemaName"."#${childWhere.model.dbName}" where "#${childWhere.field.dbName}" = ${childWhere.fieldValue}""").asUpdate
+        sql"""FROM "#$schemaName"."#${childWhere.model.dbName}" where "#${childWhere.field.dbName}" = ${childWhere.fieldValue}
+             ON CONFLICT DO NOTHING
+           """).asUpdate
+
     }
 //    https://stackoverflow.com/questions/1109061/insert-on-duplicate-update-in-postgresql
 //    ++

--- a/server/connectors/api-connector-postgresql/src/main/scala/com/prisma/api/connector/postgresql/impl/PostgresDatabaseMutactionExecutor.scala
+++ b/server/connectors/api-connector-postgresql/src/main/scala/com/prisma/api/connector/postgresql/impl/PostgresDatabaseMutactionExecutor.scala
@@ -21,7 +21,7 @@ case class PostgresDatabaseMutactionExecutor(clientDb: Database)(implicit ec: Ex
     }
 
     clientDb
-      .run(singleAction.withTransactionIsolation(TransactionIsolation.ReadCommitted))
+      .run(singleAction)
       .recover { case error => throw combinedErrorMapper.lift(error).getOrElse(error) }
   }
 

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseMutationBuilder.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseMutationBuilder.scala
@@ -138,8 +138,10 @@ object PostgresDeployDatabaseMutationBuilder {
     ;"""
 
     val indexCreate = sqlu"""CREATE UNIQUE INDEX "#${relationTableName}_AB_unique" on  "#$projectId"."#$relationTableName" ("A" ASC, "B" ASC)"""
+    val indexA      = sqlu"""CREATE UNIQUE INDEX "#${relationTableName}_A_unique" on  "#$projectId"."#$relationTableName" ("A" ASC)"""
+    val indexB      = sqlu"""CREATE UNIQUE INDEX "#${relationTableName}_B_unique" on  "#$projectId"."#$relationTableName" ("B" ASC)"""
 
-    DBIOAction.seq(tableCreate, indexCreate)
+    DBIOAction.seq(tableCreate, indexCreate, indexA, indexB)
   }
 
   def createRelationColumn(projectId: String, model: Model, field: Option[Field], references: Model, column: String) = {

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseMutationBuilder.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseMutationBuilder.scala
@@ -138,8 +138,8 @@ object PostgresDeployDatabaseMutationBuilder {
     ;"""
 
     val indexCreate = sqlu"""CREATE UNIQUE INDEX "#${relationTableName}_AB_unique" on  "#$projectId"."#$relationTableName" ("A" ASC, "B" ASC)"""
-    val indexA      = sqlu"""CREATE UNIQUE INDEX "#${relationTableName}_A_unique" on  "#$projectId"."#$relationTableName" ("A" ASC)"""
-    val indexB      = sqlu"""CREATE UNIQUE INDEX "#${relationTableName}_B_unique" on  "#$projectId"."#$relationTableName" ("B" ASC)"""
+    val indexA      = sqlu"""CREATE INDEX "#${relationTableName}_A" on  "#$projectId"."#$relationTableName" ("A" ASC)"""
+    val indexB      = sqlu"""CREATE INDEX "#${relationTableName}_B" on  "#$projectId"."#$relationTableName" ("B" ASC)"""
 
     DBIOAction.seq(tableCreate, indexCreate, indexA, indexB)
   }


### PR DESCRIPTION
- do not set default isolation level on every transaction
- create indexes on columns of relation table
- do nothing during conflicts on relation tables