### PR TITLE
fix: codegen, downgrade npm-run in prisma cli

### DIFF
--- a/cli/packages/prisma-cli-core/package.json
+++ b/cli/packages/prisma-cli-core/package.json
@@ -104,7 +104,7 @@
     "lodash.differenceby": "^4.8.0",
     "multimatch": "^2.1.0",
     "node-forge": "^0.7.1",
-    "npm-run": "^5.0.1",
+    "npm-run": "4.1.2",
     "opn": "^5.1.0",
     "pause": "^0.1.0",
     "portfinder": "^1.0.13",


### PR DESCRIPTION
npm-run 5.x is broken on windows
https://github.com/timoxley/npm-run/issues/19