### PR TITLE
Use user provided schema or default to public.

### DIFF
--- a/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
+++ b/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
@@ -267,14 +267,14 @@ export class EndpointDialog {
         } catch (e) {
           throw new Error(`Could not connect to database. ${e.message}`)
         }
-        // TODO: ask for postres schema if more than one
+
         if (
           credentials &&
           credentials.alreadyData &&
           schemas &&
           schemas.length > 0
         ) {
-          const { numTables, sdl } = await introspector.introspect(schemas[0])
+          const { numTables, sdl } = await introspector.introspect(credentials.schema || schemas[0])
           if (numTables === 0) {
             this.out.log(
               chalk.red(


### PR DESCRIPTION
I had issue introspecting a specified schema and then figured out that my selection wasn't even passed to introspect method.

I removed TODO since CLI always asks for schema, so maybe there should be no fallback to `public` or `schemas[0]` which was `public` in my case.