### PR TITLE
Fix hooks experience in CLI

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/deploy/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/deploy/index.ts
@@ -21,6 +21,7 @@ import Up from '../local/up'
 import { EndpointDialog } from '../../utils/EndpointDialog'
 import { isDockerComposeInstalled } from '../../utils/dockerComposeInstalled'
 import { spawnSync } from 'npm-run'
+import * as figures from 'figures'
 
 export default class Deploy extends Command {
   static topic = 'deploy'
@@ -457,10 +458,15 @@ ${chalk.gray(
         this.out.log(stderr)
       }
       const stdout = child.stdout && child.stdout.toString()
-      if (stdout) {
+      if (stdout && stdout.length > 0) {
         this.out.log(stdout)
       }
-      this.out.action.stop()
+      const {status} = child
+      if (status != 0) {
+        this.out.action.stop(chalk.red(figures.cross))
+      } else {
+        this.out.action.stop()
+      }
     }
   }
 

--- a/cli/packages/prisma-cli-core/src/commands/deploy/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/deploy/index.ts
@@ -455,14 +455,17 @@ ${chalk.gray(
       const child = spawnSync(splittedHook[0], splittedHook.slice(1))
       const stderr = child.stderr && child.stderr.toString()
       if (stderr && stderr.length > 0) {
-        this.out.log(stderr)
+        this.out.log(chalk.red(stderr))
       }
       const stdout = child.stdout && child.stdout.toString()
       if (stdout && stdout.length > 0) {
         this.out.log(stdout)
       }
-      const {status} = child
-      if (status != 0) {
+      const {status, error} = child
+      if (error || status != 0) {
+        if (error) {
+          this.out.log(chalk.red(error.message))
+        }
         this.out.action.stop(chalk.red(figures.cross))
       } else {
         this.out.action.stop()


### PR DESCRIPTION
This PR intends to solve https://github.com/prismagraphql/prisma/issues/2362 and related issues (https://github.com/prismagraphql/prisma/issues/2560).

Observations:-

1. Underlying packages (`graphql-cli`, `graphql-config` etc) do not write to `stderr` or emit non-zero status code on failure

1. Prisma CLI does not always check the status

1. There are (race?)-conditions that call stop function and render green unintended messages on CLI

1. We cannot aggressively fail `prisma deploy` on failing `hooks` as deployment might already be done. Need to extract the errors gracefully and communicate them back to the user