### PR TITLE
Docs: fix `.graphqlconfig.yml` typo in tutorials

### DIFF
--- a/docs/1.8/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
+++ b/docs/1.8/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
@@ -206,7 +206,7 @@ Put the following contents into it, defining the two GraphQL APIs you're working
 ```yml
 projects:
   app:
-    schemPath: src/schema.graphql
+    schemaPath: src/schema.graphql
     extensions:
       endpoints:
         default: http://localhost:4000

--- a/docs/1.8/03-Tutorials2/03-Access-Prisma-from-Scripts/01-Access-Prisma-from-a-Node-script-using-Prisma-Bindings.md
+++ b/docs/1.8/03-Tutorials2/03-Access-Prisma-from-Scripts/01-Access-Prisma-from-a-Node-script-using-Prisma-Bindings.md
@@ -147,7 +147,7 @@ Put the following contents into it, defining the two GraphQL APIs you're working
 ```yml
 projects:
   app:
-    schemPath: src/schema.graphql
+    schemaPath: src/schema.graphql
     extensions:
       endpoints:
         default: http://localhost:4000

--- a/docs/1.9/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
+++ b/docs/1.9/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
@@ -206,7 +206,7 @@ Put the following contents into it, defining the two GraphQL APIs you're working
 ```yml
 projects:
   app:
-    schemPath: src/schema.graphql
+    schemaPath: src/schema.graphql
     extensions:
       endpoints:
         default: http://localhost:4000


### PR DESCRIPTION
I was working through the tutorials on the Prisma docs site, and noticed what looks like a typo in some of the `.graphqlconfig.yml` examples. It looks like `projects.app.schemPath` should be  `schemaPath` instead.

Assuming this is a typo, this PR fixes it. 