### PR TITLE
Fix playground crashing on chromeos

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/playground/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/playground/index.ts
@@ -79,7 +79,7 @@ export default class Playground extends Command {
       const link = await this.startServer({ config, endpoint, port })
 
       if (shouldOpenBrowser) {
-        opn(link)
+        opn(link).catch(() => {}); // Prevent `unhandledRejection` error.
       }
     } else {
       const envPath = path.join(os.tmpdir(), `${randomString()}.json`)


### PR DESCRIPTION
Copied from https://github.com/facebook/create-react-app/blob/next/packages/react-dev-utils/openBrowser.js#L100

Fixes: https://github.com/prismagraphql/prisma/issues/2592

Related to: https://github.com/prismagraphql/prisma/pull/2596