### PR TITLE
Fix typo in `Concepts.md` doc

### DIFF
--- a/docs/1.9/04-Reference/03-Prisma-API/02-Concepts.md
+++ b/docs/1.9/04-Reference/03-Prisma-API/02-Concepts.md
@@ -250,7 +250,7 @@ The JWT must contain different [claims](https://jwt.io/introduction/#payload):
 
 > In the future there might be support for more fine grained access control by introducing a concept of roles such as `["write:Log", "read:*"]`
 
-Here is the sample Payload of a JTW.
+Here is the sample Payload of a JWT.
 
 ```json
 {


### PR DESCRIPTION
In the `Concepts.md` file, **JWT** has been written **JTW**. This MR fixes that word.