### PR TITLE
Not prompted, given endpoint

### DIFF
--- a/docs/1.10/03-Tutorials2/02-Build-GraphQL-Servers/02-Auth/01-Permissions.md
+++ b/docs/1.10/03-Tutorials2/02-Build-GraphQL-Servers/02-Auth/01-Permissions.md
@@ -40,7 +40,7 @@ graphql create permissions-example --boilerplate node-advanced
 
 <Instruction>
 
-When prompted where (i.e. to which _cluster_) to deploy your Prisma service, choose one of the _public cluster_ options: `prisma-eu1` or `prisma-us1`.
+In the output you'll be given a public endpoint which will look like `https://eu1.prisma.sh/public-example-123/permissions-example/dev`.
 
 </Instruction>
 


### PR DESCRIPTION
When I run the command:

`graphql create permissions-example --boilerplate node-advanced`

I'm not prompted to choose a public endpoint, but rather given one like so:

```
Your Prisma GraphQL database endpoint is live:

  HTTP:  https://eu1.prisma.sh/public-example-123/permissions-example/dev
  WS:    wss://eu1.prisma.sh/public-example-123/permissions-example/dev
```