### PR TITLE
docs(graphql-yoga overview): fix examples link

### DIFF
--- a/docs/1.11/06-GraphQL-Ecosystem/01-GraphQL-Yoga/01-Overview.md
+++ b/docs/1.11/06-GraphQL-Ecosystem/01-GraphQL-Yoga/01-Overview.md
@@ -63,7 +63,7 @@ const server = new GraphQLServer({ typeDefs, resolvers })
 server.start(() => console.log('Server is running on localhost:4000'))
 ```
 
-> To get started with `graphql-yoga`, follow the instructions in the READMEs of the [examples](./examples).
+> To get started with `graphql-yoga`, follow the instructions in the READMEs of the [examples](https://github.com/prismagraphql/prisma/tree/master/examples).
 
 ### API
 


### PR DESCRIPTION
At https://www.prisma.io/docs/graphql-ecosystem/graphql-yoga/overview-chaha122ho/#quickstart-(hosted-demo), the link to examples is broken in

> To get started with `graphql-yoga`, follow the instructions in the READMEs of the **examples**.