### PR TITLE
fix - workspace * not found issue in delete, seed command

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/delete/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/delete/index.ts
@@ -33,7 +33,7 @@ export default class Delete extends Command {
       cluster!,
       serviceName,
       stage,
-      this.definition.getWorkspace() || '*',
+      this.definition.getWorkspace(),
     )
 
     const prettyName = `${chalk.bold(serviceName)}@${stage}`
@@ -47,7 +47,7 @@ export default class Delete extends Command {
     await this.client.deleteProject(
       serviceName,
       stage,
-      this.definition.getWorkspace(),
+      this.definition.getWorkspace() || (this.env.activeCluster.workspaceSlug as string),
     )
     this.out.action.stop(prettyTime(Date.now() - before))
   }

--- a/cli/packages/prisma-cli-core/src/commands/seed/seed.ts
+++ b/cli/packages/prisma-cli-core/src/commands/seed/seed.ts
@@ -37,7 +37,7 @@ export default class Seed extends Command {
       cluster!,
       serviceName,
       this.definition.stage,
-      this.definition.getWorkspace() || '*',
+      this.definition.getWorkspace(),
     )
 
     const seed = this.definition.definition!.seed


### PR DESCRIPTION
Explanation of this PR

1. Fixes https://github.com/prismagraphql/prisma/issues/2757
2. No need to pass ` ... || "*"` as [`generateClusterToken`](https://github.com/prismagraphql/prisma/blob/4aa244a701ccfa3f9592a434c0988333001ba13d/cli/packages/prisma-yml/src/Cluster.ts#L107) function handles it by finding workspace slug from current active cluster. 
3. Use [similar approach](https://github.com/prismagraphql/prisma/compare/alpha...divyenduz:fix_workspace_issue?expand=1#diff-eb530b627d82cbff26b121734874cff8R50) to point 2, to pass correct workspace to `deleteService` call

Please let me know if any changes are needed. 