### PR TITLE
fix: NDF validator, do not check all required scalar lists

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/import/Validator.ts
+++ b/cli/packages/prisma-cli-core/src/commands/import/Validator.ts
@@ -117,7 +117,6 @@ export class Validator {
   validateListNode(obj: any): true {
     this.checkTypeName(obj)
     this.checkIdField(obj)
-    this.checkRequiredFields(obj, true)
     this.checkUnknownFields(obj, true)
     this.checkType(obj, true)
     return true
@@ -126,7 +125,6 @@ export class Validator {
   validateRelationNode(node: RelationNode): true {
     this.checkTypeName(node)
     this.checkIdField(node)
-    // this.checkFieldName(node)
     return true
   }
 


### PR DESCRIPTION
Do not check all scalar fields in one NDF list JSON object. This is by design. 

Fixes https://github.com/prismagraphql/prisma/issues/2731