### PR TITLE
fix: deprecate cluster command

### DIFF
--- a/cli/packages/prisma-cli-engine/src/Dispatcher/Dispatcher.ts
+++ b/cli/packages/prisma-cli-engine/src/Dispatcher/Dispatcher.ts
@@ -104,6 +104,9 @@ export class Dispatcher {
 
   async findTopic(id: string) {
     if (!id) return {}
+    // TODO: Fix this hack for "cluster". 
+    // Find why cache does not invalidate for cluster command
+    if (id.trim() === 'cluster') return null
     for (let manager of this.managers) {
       let topic = await manager.findTopic(id)
       if (topic) return topic


### PR DESCRIPTION
@timsuchanek - The plugin manager uses cached topics and still yields the command `cluster`. I already tried the `GRAPHCOOL_CLI_CLEAR_CACHE` environment variable. 

This PR is a hot fix to deprecate the cluster command. We can work on finding out the actual cause of this issue later. 

The same issue is not observed for the `local` command. 

Finally, fixes https://github.com/prismagraphql/prisma/issues/2666